### PR TITLE
Better dictionary encoding user experience

### DIFF
--- a/src/parquet/column/writer.cc
+++ b/src/parquet/column/writer.cc
@@ -182,9 +182,8 @@ void TypedColumnWriter<Type>::WriteDictionaryPage() {
   // TODO Get rid of this deep call
   dict_encoder->mem_pool()->FreeAll();
 
-  Encoding::type dict_encoding = Encoding::PLAIN_DICTIONARY;
-  if (encoding_ == Encoding::RLE_DICTIONARY) { dict_encoding = Encoding::PLAIN; }
-  DictionaryPage page(buffer, dict_encoder->num_entries(), dict_encoding);
+  DictionaryPage page(
+      buffer, dict_encoder->num_entries(), properties_->dictionary_index_encoding());
   total_bytes_written_ += pager_->WriteDictionaryPage(page);
 }
 
@@ -195,6 +194,9 @@ std::shared_ptr<ColumnWriter> ColumnWriter::Make(const ColumnDescriptor* descr,
     std::unique_ptr<PageWriter> pager, int64_t expected_rows,
     const WriterProperties* properties) {
   Encoding::type encoding = properties->encoding(descr->path());
+  if (properties->dictionary_enabled(descr->path())) {
+    encoding = properties->dictionary_encoding();
+  }
   switch (descr->physical_type()) {
     case Type::BOOLEAN:
       return std::make_shared<BoolWriter>(

--- a/src/parquet/file/metadata-internal.cc
+++ b/src/parquet/file/metadata-internal.cc
@@ -306,14 +306,14 @@ class ColumnMetaDataBuilder::ColumnMetaDataBuilderImpl {
     column_chunk_->meta_data.__set_total_compressed_size(compressed_size);
     std::vector<format::Encoding::type> thrift_encodings;
     thrift_encodings.push_back(ToThrift(properties_->level_encoding()));
-    if (properties_->dictionary_enabled()) {
+    if (properties_->dictionary_enabled(column_->path())) {
       thrift_encodings.push_back(ToThrift(properties_->dictionary_encoding()));
       // add the encoding only if it is unique
       if (properties_->version() == ParquetVersion::PARQUET_2_0) {
         thrift_encodings.push_back(ToThrift(properties_->dictionary_index_encoding()));
       }
     }
-    if (!properties_->dictionary_enabled() || dictionary_fallback) {
+    if (!properties_->dictionary_enabled(column_->path()) || dictionary_fallback) {
       thrift_encodings.push_back(ToThrift(properties_->encoding(column_->path())));
     }
     column_chunk_->meta_data.__set_encodings(thrift_encodings);


### PR DESCRIPTION
PR for the PR ;)

Before we discuss more in circles (yes, it's probably mainly my fault :P), I just implemented the one solution.

@majetideepak I made this a PR for your PR so there are no merge conflicts and it can be directly integrated in your change.

@wesm Hope that reflects your expectations. Fallback is available in the properties as it should be, the switch to fall back in the ColumnWriter will then be handled in a separate PR. 
